### PR TITLE
FIX: allow v4 of activesupport

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,22 +2,22 @@ PATH
   remote: .
   specs:
     sidekiq_workflows (0.2.1)
-      activesupport (~> 5.0)
+      activesupport (~> 4.0)
       sidekiq-pro (~> 4.0, >= 4.0.2)
 
 GEM
   remote: https://rubygems.org/
   remote: https://gems.contribsys.com/
   specs:
-    activesupport (5.2.1)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
+    activesupport (4.2.11.1)
+      i18n (~> 0.7)
       minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.2)
-    i18n (1.1.0)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     metaclass (0.0.4)
     method_source (0.9.0)

--- a/sidekiq_workflows.gemspec
+++ b/sidekiq_workflows.gemspec
@@ -1,4 +1,4 @@
-Gem::Specification.new 'sidekiq_workflows', '0.2.1' do |s|
+Gem::Specification.new 'sidekiq_workflows', '0.2.2' do |s|
   s.licenses = %w[MIT]
   s.summary = "Sidekiq extension providing a workflow API on top of Sidekiq Pro's batches"
   s.description = "Sidekiq extension providing a workflow API on top of Sidekiq Pro's batches"
@@ -9,7 +9,7 @@ Gem::Specification.new 'sidekiq_workflows', '0.2.1' do |s|
     Rakefile
   ] + Dir['lib/**/*']
   s.add_dependency 'sidekiq-pro', '~> 4.0', '>= 4.0.2'
-  s.add_dependency 'activesupport', '~> 5.0'
+  s.add_dependency 'activesupport', '~> 4.0'
   s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'mocha', '~> 1.3'
   s.add_development_dependency 'minitest', '~> 5.0'


### PR DESCRIPTION
This PR allows folks using older versions of Rails to have ActiveSupport v4 (not v5).

Tests run OK.