### PR TITLE
Call super.perform_async instead of send(:perform_async)

### DIFF
--- a/lib/sidekiq_workflows/worker.rb
+++ b/lib/sidekiq_workflows/worker.rb
@@ -43,7 +43,8 @@ module SidekiqWorkflows
     end
 
     def self.perform_async(workflow, *args)
-      set(queue: worker_queue).send(:perform_async, workflow.serialize, *args)
+      set(queue: worker_queue)
+      super(workflow.serialize, *args)
     end
 
     def self.perform_workflow(workflow, on_complete: nil, on_complete_options: {})


### PR DESCRIPTION
Using `set(queue: worker_queue).send(:perform_async, workflow.serialize, *args)` causes and endless loop of worker.serialization / deserialization and `perfom` never gets called.